### PR TITLE
Test with PHP8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
 
 env:
   global:
+    - RUN_PHPCSFIXER="TRUE"
+    - RUN_PHPUNIT="TRUE"
     - RUN_PHPSTAN="FALSE"
   matrix:
     - PREFER_LOWEST="" REPORT_COVERAGE="TRUE" WITH_COVERAGE="--coverage-clover=coverage.xml"
@@ -17,16 +19,19 @@ matrix:
     - name: 'PHPStan'
       php: 7.4
       env:
+        - RUN_PHPCSFIXER="FALSE"
+        - RUN_PHPUNIT="FALSE"
         - RUN_PHPSTAN="TRUE"
         - REPORT_COVERAGE="FALSE"
   fast_finish: true
 
 before_script:
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
 
 script:
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
+  - if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPUNIT == "TRUE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
   - if [ $RUN_PHPSTAN == "TRUE" ]; then composer phpstan; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ env:
 
 matrix:
   include:
+    - name: 'PHP8'
+      dist: focal
+      php: nightly
+      env:
+        - RUN_PHPCSFIXER="FALSE"
+        - REPORT_COVERAGE="FALSE"
     - name: 'PHPStan'
       php: 7.4
       env:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "homepage": "http://sabre.io/dav/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "sabre/http" : "^5.0",
         "sabre/uri" : "^2.1"
     },


### PR DESCRIPTION
1) sort out variables in `.travis.yml` for selecting to run php-cs-fixer, phpunit and phpstan
2) Add a matrix entry to run just phpunit on Ubuntu 20.04 "focal" with "nightly" PHP (which is the way to get PHP 8.0 at the moment)
3) When not running php-cs-fixer, explicitly remove it from `composer.json` (because php-cs-fixer does not yet support PHP 8.0, so composer cannot sort out dependencies if we have PHP 8.0 and php-cs-fixer 2.* together)
